### PR TITLE
force command

### DIFF
--- a/scripts/whoop.py
+++ b/scripts/whoop.py
@@ -109,9 +109,19 @@ async def command_listener(client):
             pkt = await cmdresp.get()
             print(pkt)
         elif command == "force":
-            # have not gotten this to work, in android app it seems to be some 8 byte buffer with 2 ints in it - which I would think correspond to the log!
-            pkt = WhoopPacket(PacketType.COMMAND, 10, CommandNumber.FORCE_TRIM, data=struct.pack("<LL", 0, 0)).framed_packet()
-            await client.write_gatt_char(WHOOP_CHAR_CMD_TO_STRAP, pkt)
+            # from https://github.com/bWanShiTong/reverse-engineering-whoop-post/blob/master/README.md#erase-device
+            hex_strings = [
+                "aa10005723cf19fefefefefefefefe002f8744f6",
+                "aa10005723d219fefefefefefefefe00e30e2693",
+                "aa10005723d319fefefefefefefefe0023d1a852"
+            ]
+
+            for s in hex_strings:
+                data = bytes.fromhex(s)
+
+                pkt = WhoopPacket(PacketType.COMMAND, 10, CommandNumber.FORCE_TRIM, data=data).framed_packet()
+                await client.write_gatt_char(WHOOP_CHAR_CMD_TO_STRAP, data)
+
         elif command == "test":
             
             verbose = True


### PR DESCRIPTION
Hey, i found some interesting info in bWanShiTongs repo regarding the FORCE_TRIM command, which has successfully deleted the data from my Whoop bracelet. Sending these strings as data for the FORCE_TRIM command returns a valid TRIM_ALL_DATA event from the bracelet like this:
```
> force
cmd: aa0c00fc24df19cf01000000558bb5b2
WhoopPacket: type[PacketType.COMMAND_RESPONSE] seq[0xdf] cmd[CommandNumber.FORCE_TRIM] data[cf01000000]
events: aa10005730b71a00f8aeac67883b0000ebc3c557
WhoopPacket: type[PacketType.EVENT] seq[0xb7] event(EventNumber.TRIM_ALL_DATA) data[00f8aeac67883b0000]
cmd: aa0c00fc24e019d201000000dd0dee74
WhoopPacket: type[PacketType.COMMAND_RESPONSE] seq[0xe0] cmd[CommandNumber.FORCE_TRIM] data[d201000000]
events: aa10005730b81a00f8aeac67f8610000d73c29ce
WhoopPacket: type[PacketType.EVENT] seq[0xb8] event(EventNumber.TRIM_ALL_DATA) data[00f8aeac67f8610000]
events: aa10005730b91a00f9aeac6750080000cc22d40c
WhoopPacket: type[PacketType.EVENT] seq[0xb9] event(EventNumber.TRIM_ALL_DATA) data[00f9aeac6750080000]
> cmd: aa0c00fc24e119d301000000d92ff9ef
WhoopPacket: type[PacketType.COMMAND_RESPONSE] seq[0xe1] cmd[CommandNumber.FORCE_TRIM] data[d301000000]
```

Not sure if I need to send all three strings but so far it's working